### PR TITLE
Add DB tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "fake-indexeddb": "^4.0.2",
         "husky": "^8.0.3",
         "lint-staged": "^14.0.1",
         "prettier": "^3.0.0",
@@ -5751,6 +5752,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-arraybuffer-es6": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.7.0.tgz",
+      "integrity": "sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -8587,6 +8597,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-4.0.2.tgz",
+      "integrity": "sha512-SdTwEhnakbgazc7W3WUXOJfGmhH0YfG4d+dRPOFoYDRTL6U5t8tvrmkf2W/C3W1jk2ylV7Wrnj44RASqpX/lEw==",
+      "dev": true,
+      "dependencies": {
+        "realistic-structured-clone": "^3.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -15774,6 +15793,32 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/realistic-structured-clone": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-3.0.0.tgz",
+      "integrity": "sha512-rOjh4nuWkAqf9PWu6JVpOWD4ndI+JHfgiZeMmujYcPi+fvILUu7g6l26TC1K5aBIp34nV+jE1cDO75EKOfHC5Q==",
+      "dev": true,
+      "dependencies": {
+        "domexception": "^1.0.1",
+        "typeson": "^6.1.0",
+        "typeson-registry": "^1.0.0-alpha.20"
+      }
+    },
+    "node_modules/realistic-structured-clone/node_modules/domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "dependencies": {
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/realistic-structured-clone/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
@@ -17612,6 +17657,29 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/typeson": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/typeson/-/typeson-6.1.0.tgz",
+      "integrity": "sha512-6FTtyGr8ldU0pfbvW/eOZrEtEkczHRUtduBnA90Jh9kMPCiFNnXIon3vF41N0S4tV1HHQt4Hk1j4srpESziCaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
+    "node_modules/typeson-registry": {
+      "version": "1.0.0-alpha.39",
+      "resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.39.tgz",
+      "integrity": "sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==",
+      "dev": true,
+      "dependencies": {
+        "base64-arraybuffer-es6": "^0.7.0",
+        "typeson": "^6.0.0",
+        "whatwg-url": "^8.4.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -22715,6 +22783,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-arraybuffer-es6": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.7.0.tgz",
+      "integrity": "sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==",
+      "dev": true
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -24741,6 +24815,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
+      }
+    },
+    "fake-indexeddb": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-4.0.2.tgz",
+      "integrity": "sha512-SdTwEhnakbgazc7W3WUXOJfGmhH0YfG4d+dRPOFoYDRTL6U5t8tvrmkf2W/C3W1jk2ylV7Wrnj44RASqpX/lEw==",
+      "dev": true,
+      "requires": {
+        "realistic-structured-clone": "^3.0.0"
       }
     },
     "fast-deep-equal": {
@@ -29632,6 +29715,34 @@
         "picomatch": "^2.2.1"
       }
     },
+    "realistic-structured-clone": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-3.0.0.tgz",
+      "integrity": "sha512-rOjh4nuWkAqf9PWu6JVpOWD4ndI+JHfgiZeMmujYcPi+fvILUu7g6l26TC1K5aBIp34nV+jE1cDO75EKOfHC5Q==",
+      "dev": true,
+      "requires": {
+        "domexception": "^1.0.1",
+        "typeson": "^6.1.0",
+        "typeson-registry": "^1.0.0-alpha.20"
+      },
+      "dependencies": {
+        "domexception": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+          "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+          "dev": true,
+          "requires": {
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        }
+      }
+    },
     "recursive-readdir": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
@@ -30969,6 +31080,23 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+    },
+    "typeson": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/typeson/-/typeson-6.1.0.tgz",
+      "integrity": "sha512-6FTtyGr8ldU0pfbvW/eOZrEtEkczHRUtduBnA90Jh9kMPCiFNnXIon3vF41N0S4tV1HHQt4Hk1j4srpESziCaA==",
+      "dev": true
+    },
+    "typeson-registry": {
+      "version": "1.0.0-alpha.39",
+      "resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.39.tgz",
+      "integrity": "sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==",
+      "dev": true,
+      "requires": {
+        "base64-arraybuffer-es6": "^0.7.0",
+        "typeson": "^6.0.0",
+        "whatwg-url": "^8.4.0"
+      }
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "fake-indexeddb": "^4.0.2",
     "husky": "^8.0.3",
     "lint-staged": "^14.0.1",
     "prettier": "^3.0.0",

--- a/src/pages/Events/sync.js
+++ b/src/pages/Events/sync.js
@@ -79,15 +79,13 @@ export async function syncRegforms(event, signal, errorModal) {
 
       // no bulkUpdate yet..
       // regforms that don't exist in Indico anymore, mark them as deleted
-      await db.transaction('readwrite', db.regforms, async () => {
-        const existingIds = onlyExisting.map(r => r.id);
-        const deleted = onlyExisting.map(() => ({deleted: true}));
-        await bulkUpdate(db.regforms, existingIds, deleted);
-        // regforms that we have both locally and in Indico, just update them
-        const commonIds = common.map(([r]) => r.id);
-        const commonData = common.map(([, r]) => r);
-        await bulkUpdate(db.regforms, commonIds, commonData);
-      });
+      const existingIds = onlyExisting.map(r => r.id);
+      const deleted = onlyExisting.map(() => ({deleted: true}));
+      await bulkUpdate(db.regforms, existingIds, deleted);
+      // regforms that we have both locally and in Indico, just update them
+      const commonIds = common.map(([r]) => r.id);
+      const commonData = common.map(([, r]) => r);
+      await bulkUpdate(db.regforms, commonIds, commonData);
     });
   } else {
     handleError(response, 'Something went wrong when updating registration forms', errorModal);
@@ -150,14 +148,14 @@ export async function syncParticipants(event, regform, signal, errorModal) {
       );
       const [onlyExisting, onlyNew, common] = split(existingParticipants, newParticipants);
 
-      // regforms that don't exist in Indico anymore, mark them as deleted
+      // participants that don't exist in Indico anymore, mark them as deleted
       const existingIds = onlyExisting.map(r => r.id);
       const deleted = onlyExisting.map(() => ({deleted: true}));
       await bulkUpdate(db.participants, existingIds, deleted);
-      // regforms that we don't have locally, add them
+      // participants that we don't have locally, add them
       const newData = onlyNew.map(r => ({...r, notes: '', deleted: false, regformId: regform.id}));
       await db.participants.bulkAdd(newData);
-      // regforms that we have both locally and in Indico, just update them
+      // participants that we have both locally and in Indico, just update them
       const commonIds = common.map(([r]) => r.id);
       const commonData = common.map(([, r]) => r);
       await bulkUpdate(db.participants, commonIds, commonData);

--- a/src/pages/Events/sync.test.js
+++ b/src/pages/Events/sync.test.js
@@ -1,0 +1,419 @@
+import 'fake-indexeddb/auto';
+import db from '../../db/db';
+import {
+  getEvent,
+  getParticipant,
+  getRegform,
+  getRegforms,
+  getParticipants,
+} from '../../utils/client';
+import {
+  syncEvents,
+  syncEvent,
+  syncParticipant,
+  syncRegform,
+  syncRegforms,
+  syncParticipants,
+} from './sync';
+
+jest.mock('../../utils/client', () => {
+  return {
+    getEvent: jest.fn(),
+    getRegforms: jest.fn(),
+    getRegform: jest.fn(),
+    getParticipants: jest.fn(),
+    getParticipant: jest.fn(),
+  };
+});
+
+async function resetDB() {
+  await db.delete();
+  await db.open();
+}
+
+async function createDummyServer() {
+  await db.servers.add({id: 1});
+}
+
+beforeEach(resetDB);
+beforeEach(createDummyServer);
+
+describe('test syncEvents()', () => {
+  test('test a successful response', async () => {
+    const errorModal = jest.fn();
+    const events = [
+      {id: 42, title: 'Mock event 1', startDt: '2020-01-01'},
+      {id: 43, title: 'Mock event 2', startDt: '2020-01-02'},
+    ];
+    getEvent
+      .mockResolvedValueOnce({ok: true, data: events[0]})
+      .mockResolvedValueOnce({ok: true, data: events[1]});
+
+    const storedEvents = [
+      {id: 1, serverId: 1},
+      {id: 2, serverId: 2},
+    ];
+    await db.events.bulkAdd(storedEvents);
+    await syncEvents(storedEvents, null, errorModal);
+
+    const updatedEvents = await db.events.toArray();
+    expect(updatedEvents).toEqual([
+      {id: 1, serverId: 1, indicoId: 42, title: 'Mock event 1', date: '2020-01-01'},
+      {id: 2, serverId: 2, indicoId: 43, title: 'Mock event 2', date: '2020-01-02'},
+    ]);
+    expect(errorModal).not.toHaveBeenCalled();
+  });
+
+  test('test a 404 response', async () => {
+    const errorModal = jest.fn();
+    getEvent.mockResolvedValue({ok: false, status: 404});
+
+    const storedEvent = {id: 1, serverId: 1};
+    await db.events.add(storedEvent);
+    await syncEvent(storedEvent, null, errorModal);
+
+    const updatedEvents = await db.events.toArray();
+    expect(updatedEvents.length).toBe(1);
+    expect(updatedEvents[0]).toEqual({id: 1, serverId: 1, deleted: true});
+    expect(errorModal).not.toHaveBeenCalled();
+  });
+
+  test('test a failed response', async () => {
+    const errorModal = jest.fn();
+    getEvent.mockResolvedValue({ok: false});
+
+    const storedEvent = {id: 1, serverId: 1};
+    await db.events.add(storedEvent);
+    await syncEvent(storedEvent, null, errorModal);
+
+    const updatedEvents = await db.events.toArray();
+    expect(updatedEvents.length).toBe(1);
+    expect(updatedEvents[0]).toEqual(storedEvent);
+    expect(errorModal).toHaveBeenCalled();
+  });
+});
+
+describe('test syncRegform()', () => {
+  test('test a successful response', async () => {
+    const errorModal = jest.fn();
+    const regform = {
+      id: 42,
+      title: 'Mock regform',
+      isOpen: true,
+      registrationCount: 12,
+      checkedInCount: 6,
+    };
+    getRegform.mockResolvedValue({ok: true, data: regform});
+
+    const storedEvent = {id: 1, serverId: 1};
+    const storedRegform = {id: 3, eventId: 1};
+    await db.events.add(storedEvent);
+    await db.regforms.add(storedRegform);
+    await syncRegform(storedEvent, storedRegform, null, errorModal);
+
+    const updatedRegforms = await db.regforms.toArray();
+    expect(updatedRegforms.length).toBe(1);
+    expect(updatedRegforms[0]).toEqual({
+      id: 3,
+      indicoId: 42,
+      eventId: 1,
+      title: 'Mock regform',
+      isOpen: true,
+      registrationCount: 12,
+      checkedInCount: 6,
+    });
+    expect(errorModal).not.toHaveBeenCalled();
+  });
+
+  test('test a 404 response', async () => {
+    const errorModal = jest.fn();
+    getRegform.mockResolvedValue({ok: false, status: 404});
+
+    const storedEvent = {id: 1, serverId: 1};
+    const storedRegform = {id: 3, eventId: 1};
+    await db.events.add(storedEvent);
+    await db.regforms.add(storedRegform);
+    await syncRegform(storedEvent, storedRegform, null, errorModal);
+
+    const updatedRegforms = await db.regforms.toArray();
+    expect(updatedRegforms.length).toBe(1);
+    expect(updatedRegforms[0]).toEqual({
+      id: 3,
+      eventId: 1,
+      deleted: true,
+    });
+    expect(errorModal).not.toHaveBeenCalled();
+  });
+
+  test('test a failed response', async () => {
+    const errorModal = jest.fn();
+    getRegform.mockResolvedValue({ok: false});
+
+    const storedEvent = {id: 1, serverId: 1};
+    const storedRegform = {id: 3, eventId: 1};
+    await db.events.add(storedEvent);
+    await db.regforms.add(storedRegform);
+    await syncRegform(storedEvent, storedRegform, null, errorModal);
+
+    const updatedRegforms = await db.regforms.toArray();
+    expect(updatedRegforms.length).toBe(1);
+    expect(updatedRegforms[0]).toEqual(storedRegform);
+    expect(errorModal).toHaveBeenCalled();
+  });
+});
+
+describe('test syncRegforms()', () => {
+  test('test a successful response', async () => {
+    const errorModal = jest.fn();
+    const regforms = [
+      {
+        id: 10,
+        title: 'Mock regform 10',
+        isOpen: false,
+        registrationCount: 2,
+        checkedInCount: 1,
+      },
+      {
+        id: 30,
+        title: 'Mock regform 30',
+        isOpen: true,
+        registrationCount: 0,
+        checkedInCount: 0,
+      },
+    ];
+    getRegforms.mockResolvedValue({ok: true, data: regforms});
+
+    const storedEvent = {id: 1, serverId: 1};
+    const storedRegforms = [
+      {id: 1, indicoId: 10, eventId: 1},
+      {id: 2, indicoId: 20, eventId: 1},
+    ];
+    await db.events.add(storedEvent);
+    await db.regforms.bulkAdd(storedRegforms);
+    await syncRegforms(storedEvent, null, errorModal);
+
+    const updatedRegforms = await db.regforms.toArray();
+    expect(updatedRegforms.length).toBe(2);
+    expect(updatedRegforms).toEqual([
+      {
+        id: 1,
+        indicoId: 10,
+        eventId: 1,
+        title: 'Mock regform 10',
+        isOpen: false,
+        registrationCount: 2,
+        checkedInCount: 1,
+      },
+      {
+        id: 2,
+        indicoId: 20,
+        eventId: 1,
+        deleted: true,
+      },
+    ]);
+    expect(errorModal).not.toHaveBeenCalled();
+  });
+
+  test('test a failed response', async () => {
+    const errorModal = jest.fn();
+    getRegforms.mockResolvedValue({ok: false});
+
+    const storedEvent = {id: 1, serverId: 1};
+    const storedRegforms = [
+      {id: 1, indicoId: 10, eventId: 1},
+      {id: 2, indicoId: 20, eventId: 1},
+    ];
+    await db.events.add(storedEvent);
+    await db.regforms.bulkAdd(storedRegforms);
+    await syncRegforms(storedEvent, null, errorModal);
+
+    const updatedRegforms = await db.regforms.toArray();
+    expect(updatedRegforms.length).toBe(2);
+    expect(updatedRegforms).toEqual(storedRegforms);
+    expect(errorModal).toHaveBeenCalled();
+  });
+});
+
+describe('test syncParticipant()', () => {
+  test('test a successful response', async () => {
+    const errorModal = jest.fn();
+    const participant = {
+      id: 42,
+      fullName: 'John Doe',
+      registrationDate: '2020-01-01',
+      registrationData: [],
+      state: 'complete',
+      checkedIn: true,
+      checkedInDt: '2020-01-02',
+      occupiedSlots: 3,
+    };
+    getParticipant.mockResolvedValue({ok: true, data: participant});
+
+    const storedEvent = {id: 1, serverId: 1};
+    const storedRegform = {id: 3, eventId: 1};
+    const storedParticipant = {id: 7, regformId: 3};
+    await db.events.add(storedEvent);
+    await db.regforms.add(storedRegform);
+    await db.participants.add(storedParticipant);
+    await syncParticipant(storedEvent, storedRegform, storedParticipant, null, errorModal);
+
+    const updatedParticipants = await db.participants.toArray();
+    expect(updatedParticipants.length).toBe(1);
+    expect(updatedParticipants[0]).toEqual({
+      id: 7,
+      indicoId: 42,
+      regformId: 3,
+      fullName: 'John Doe',
+      registrationDate: '2020-01-01',
+      registrationData: [],
+      state: 'complete',
+      checkedIn: true,
+      checkedInDt: '2020-01-02',
+      occupiedSlots: 3,
+    });
+    expect(errorModal).not.toHaveBeenCalled();
+  });
+
+  test('test a 404 response', async () => {
+    const errorModal = jest.fn();
+    getParticipant.mockResolvedValue({ok: false, status: 404});
+
+    const storedEvent = {id: 1, serverId: 1};
+    const storedRegform = {id: 3, eventId: 1};
+    const storedParticipant = {id: 7, regformId: 3};
+    await db.events.add(storedEvent);
+    await db.regforms.add(storedRegform);
+    await db.participants.add(storedParticipant);
+    await syncParticipant(storedEvent, storedRegform, storedParticipant, null, errorModal);
+
+    const updatedParticipants = await db.participants.toArray();
+    expect(updatedParticipants.length).toBe(1);
+    expect(updatedParticipants[0]).toEqual({
+      id: 7,
+      regformId: 3,
+      deleted: true,
+    });
+    expect(errorModal).not.toHaveBeenCalled();
+  });
+
+  test('test a failed response', async () => {
+    const errorModal = jest.fn();
+    getParticipant.mockResolvedValue({ok: false});
+
+    const storedEvent = {id: 1, serverId: 1};
+    const storedRegform = {id: 3, eventId: 1};
+    const storedParticipant = {id: 7, regformId: 3};
+    await db.events.add(storedEvent);
+    await db.regforms.add(storedRegform);
+    await db.participants.add(storedParticipant);
+    await syncParticipant({id: 1, serverId: 1}, {id: 3}, {id: 7}, null, errorModal);
+
+    const updatedParticipants = await db.participants.toArray();
+    expect(updatedParticipants.length).toBe(1);
+    expect(updatedParticipants[0]).toEqual(storedParticipant);
+    expect(errorModal).toHaveBeenCalled();
+  });
+});
+
+describe('test syncParticipants()', () => {
+  test('test a successful response', async () => {
+    const errorModal = jest.fn();
+    const participants = [
+      {
+        id: 10,
+        fullName: 'John Doe',
+        registrationDate: '2020-01-01',
+        registrationData: [],
+        state: 'complete',
+        checkedIn: true,
+        checkedInDt: '2020-01-02',
+        checkinSecret: '0000',
+        occupiedSlots: 3,
+      },
+      {
+        id: 30,
+        fullName: 'Jane Doe',
+        registrationDate: '2020-03-01',
+        registrationData: [],
+        state: 'unpaid',
+        checkedIn: true,
+        checkedInDt: null,
+        checkinSecret: '1111',
+        occupiedSlots: 1,
+      },
+    ];
+    getParticipants.mockResolvedValue({ok: true, data: participants});
+
+    const storedEvent = {id: 1, serverId: 1};
+    const storedRegform = {id: 3, eventId: 1};
+    const storedParticipants = [
+      {id: 1, indicoId: 10, regformId: 3},
+      {id: 2, indicoId: 20, regformId: 3},
+    ];
+    await db.events.add(storedEvent);
+    await db.regforms.add(storedRegform);
+    await db.participants.bulkAdd(storedParticipants);
+    await syncParticipants(storedEvent, storedRegform, null, errorModal);
+
+    const updatedParticipants = await db.participants.toArray();
+    expect(updatedParticipants.length).toBe(3);
+    expect(updatedParticipants).toEqual([
+      {
+        id: 1,
+        indicoId: 10,
+        regformId: 3,
+        fullName: 'John Doe',
+        registrationDate: '2020-01-01',
+        registrationData: [],
+        state: 'complete',
+        checkedIn: true,
+        checkedInDt: '2020-01-02',
+        checkinSecret: '0000',
+        occupiedSlots: 3,
+      },
+      {
+        id: 2,
+        indicoId: 20,
+        regformId: 3,
+        deleted: true,
+      },
+      {
+        id: 3,
+        indicoId: 30,
+        regformId: 3,
+        fullName: 'Jane Doe',
+        registrationDate: '2020-03-01',
+        registrationData: [],
+        state: 'unpaid',
+        checkedIn: true,
+        checkedInDt: null,
+        checkinSecret: '1111',
+        occupiedSlots: 1,
+        notes: '',
+        deleted: false,
+      },
+    ]);
+    expect(errorModal).not.toHaveBeenCalled();
+  });
+
+  test('test a failed response', async () => {
+    const errorModal = jest.fn();
+    getParticipants.mockResolvedValue({ok: false});
+
+    const storedEvent = {id: 1, serverId: 1};
+    const storedRegform = {id: 3, eventId: 1};
+    const storedParticipants = [
+      {id: 7, regformId: 3},
+      {id: 8, regformId: 3},
+    ];
+    await db.events.add(storedEvent);
+    await db.regforms.add(storedRegform);
+    await db.participants.bulkAdd(storedParticipants);
+    await syncParticipants(storedEvent, storedRegform, null, errorModal);
+
+    const updatedParticipants = await db.participants.toArray();
+    expect(updatedParticipants.length).toBe(2);
+    expect(updatedParticipants).toEqual(storedParticipants);
+    expect(errorModal).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds tests for functions which synchronize data with Indico.
I'm using [fakeIndexedDB](https://github.com/dumbmatter/fakeIndexedDB) which is an in-memory IDB implementation so that we can run the tests outside the browser.