### PR TITLE
Add logs for easier debugging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import db, {
   getServers,
   countParticipants,
 } from './db/db';
+import {useLogError} from './hooks/useError';
 import useSettings from './hooks/useSettings';
 import AuthRedirectPage from './pages/Auth/AuthRedirectPage';
 import EventPage from './pages/event/EventPage';
@@ -134,10 +135,29 @@ const router = createBrowserRouter([
 
 export default function App() {
   const {darkMode} = useSettings();
+  const logError = useLogError();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', darkMode);
   }, [darkMode]);
+
+  useEffect(() => {
+    function onError(event: ErrorEvent) {
+      logError(event.error);
+    }
+
+    function onUnhandledRejection(event: PromiseRejectionEvent) {
+      logError(event.reason);
+    }
+
+    window.addEventListener('error', onError);
+    window.addEventListener('unhandledrejection', onUnhandledRejection);
+
+    return () => {
+      window.removeEventListener('error', onError);
+      window.removeEventListener('unhandledrejection', onUnhandledRejection);
+    };
+  });
 
   return (
     <div className="h-full min-h-screen w-screen overflow-auto bg-gray-50 pb-32 dark:bg-gray-900">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,7 +157,7 @@ export default function App() {
       window.removeEventListener('error', onError);
       window.removeEventListener('unhandledrejection', onUnhandledRejection);
     };
-  });
+  }, [logError]);
 
   return (
     <div className="h-full min-h-screen w-screen overflow-auto bg-gray-50 pb-32 dark:bg-gray-900">

--- a/src/Components/Tailwind/Button.tsx
+++ b/src/Components/Tailwind/Button.tsx
@@ -8,8 +8,7 @@ interface ButtonProps {
 }
 
 const variants = {
-  default: `bg-primary hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:bg-blue-600
-            dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800`,
+  default: `bg-primary active:bg-blue-800 dark:bg-blue-600 dark:active:bg-blue-700 focus:outline-none`,
   success: `bg-green-500 active:bg-green-600 dark:bg-green-600 dark:active:bg-green-700 focus:outline-none`,
   warning: `bg-yellow-500 active:bg-yellow-600 dark:bg-yellow-600 dark:active:bg-yellow-700 focus:outline-none`,
 };

--- a/src/Components/Tailwind/Toggle.tsx
+++ b/src/Components/Tailwind/Toggle.tsx
@@ -37,7 +37,10 @@ export const Toggle = ({
   const dimensionsClassName = dimensionsClassNames[size];
 
   return (
-    <label className="relative inline-flex cursor-pointer items-center">
+    <label
+      style={{WebkitTapHighlightColor: 'transparent'}}
+      className="relative inline-flex cursor-pointer items-center"
+    >
       <input
         type="checkbox"
         className="peer sr-only"
@@ -49,8 +52,7 @@ export const Toggle = ({
       <div
         className={`peer bg-gray-200 after:absolute after:border after:border-gray-300
                     after:bg-white after:transition-all after:content-[''] peer-checked:bg-blue-600
-                    peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4
-                    peer-focus:ring-blue-300 dark:border-gray-600 dark:bg-gray-500 dark:peer-focus:ring-blue-800
+                    peer-checked:after:border-white dark:border-gray-600 dark:bg-gray-500
                     ${roundedProps} ${className} ${dimensionsClassName} ${
                       disabled ? 'opacity-50' : ''
                     }`}

--- a/src/context/LogsProvider.tsx
+++ b/src/context/LogsProvider.tsx
@@ -1,0 +1,48 @@
+import {ReactNode, createContext, useCallback, useState} from 'react';
+import PropTypes from 'prop-types';
+
+const MAX_LOG_COUNT = 500;
+
+export type Severity = 'info' | 'warn' | 'error';
+export type LogMessage = (severity: Severity, message: string) => void;
+
+export interface Log {
+  severity: Severity;
+  timestamp: Date;
+  message: string;
+}
+
+export const LogDataContext = createContext<{logs: Log[]}>({
+  logs: [],
+});
+
+export const LogMessageContext = createContext((severity: Severity, message: string) => {});
+
+export const LogsProvider = ({children}: {children: ReactNode}) => {
+  const [logs, setLogs] = useState<Log[]>([]);
+
+  const logMessage = useCallback(
+    (severity: Severity, message: string) => {
+      const timestamp = new Date();
+      const log: Log = {severity, timestamp, message};
+      setLogs(logs => {
+        if (logs.length < MAX_LOG_COUNT) {
+          return [...logs, log];
+        } else {
+          return [...logs.slice(1), log];
+        }
+      });
+    },
+    [setLogs]
+  );
+
+  return (
+    <LogMessageContext.Provider value={logMessage}>
+      <LogDataContext.Provider value={{logs}}>{children}</LogDataContext.Provider>
+    </LogMessageContext.Provider>
+  );
+};
+
+LogsProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/hooks/useError.test.ts
+++ b/src/hooks/useError.test.ts
@@ -1,0 +1,53 @@
+import {handleError, logError} from './useError';
+
+describe('test error handling', () => {
+  const inputs = [
+    [
+      {
+        ok: false,
+        status: 500,
+        endpoint: 'api/checkin/event/1',
+        options: {method: 'GET'},
+        data: 'something went wrong',
+      },
+      'api/checkin/event/1 {"method":"GET"} 500 "something went wrong"',
+      'Response status: 500',
+    ],
+    [
+      {
+        ok: false,
+        endpoint: 'api/checkin/event/1',
+        options: {method: 'GET'},
+        err: new Error('network unreachable'),
+      },
+      'api/checkin/event/1 {"method":"GET"} Error: network unreachable',
+      'Error: network unreachable',
+    ],
+    [
+      new TypeError('undefined has no properties'),
+      'TypeError: undefined has no properties',
+      'TypeError: undefined has no properties',
+    ],
+    ['Unhandled Promise Rejection', 'Unhandled Promise Rejection', 'Unhandled Promise Rejection'],
+  ];
+
+  test('test logError()', async () => {
+    const logMessage = jest.fn();
+
+    for (const [err, msg] of inputs) {
+      logError(err, logMessage);
+      expect(logMessage).toHaveBeenCalledWith('error', msg);
+    }
+  });
+
+  test('test handleError()', async () => {
+    const errorModal = jest.fn();
+    const logMessage = jest.fn();
+
+    for (const [err, , msg] of inputs) {
+      handleError(err, 'Something went wrong', errorModal, logMessage);
+      expect(logMessage).toHaveBeenCalled();
+      expect(errorModal).toHaveBeenCalledWith({title: 'Something went wrong', content: msg});
+    }
+  });
+});

--- a/src/hooks/useError.ts
+++ b/src/hooks/useError.ts
@@ -1,0 +1,111 @@
+import {useCallback} from 'react';
+import {LogMessage} from '../context/LogsProvider';
+import {ErrorModalFunction} from '../context/ModalContextProvider';
+import {FailedResponse} from '../utils/client';
+import {useLogMessage} from './useLogs';
+import {useErrorModal} from './useModal';
+
+function displayFetchError(response: FailedResponse, msg: string, errorModal: ErrorModalFunction) {
+  if (response.network || response.aborted) {
+    // Either a network error in which case we fallback to indexedDB,
+    // or aborted because the component unmounted
+    return;
+  } else if (response.err) {
+    errorModal({title: msg, content: String(response.err)});
+  } else {
+    errorModal({title: msg, content: `Response status: ${response.status}`});
+  }
+}
+
+function displayGenericError(err: any, msg: string, errorModal: ErrorModalFunction) {
+  errorModal({title: msg, content: String(err)});
+}
+
+function logFetchError(response: FailedResponse, logMessage: LogMessage) {
+  if (response.aborted) {
+    // Aborted because the component unmounted
+    return;
+  }
+
+  let msg = `${response.endpoint} ${JSON.stringify(response.options)}`;
+  const fields = ['status', 'err', 'data', 'description'] as (keyof FailedResponse)[];
+  for (const field of fields) {
+    if (response[field]) {
+      if (field === 'data') {
+        msg += ` ${JSON.stringify(response[field])}`;
+      } else {
+        msg += ` ${response[field]}`;
+      }
+    }
+  }
+
+  logMessage('error', msg);
+}
+
+function logGenericError(obj: any, logMessage: LogMessage) {
+  logMessage('error', String(obj));
+}
+
+function isResponse(obj: FailedResponse | any): obj is FailedResponse {
+  return obj.ok !== undefined;
+}
+
+/**
+ * Log an error. The error can be viewed on the settings page under the 'logs' section.
+ * @param obj A FailedResponse object or some other value, typically an Error object
+ * @param logMessage The function returned from 'useLogMessage'
+ */
+export function logError(obj: FailedResponse | any, logMessage: LogMessage) {
+  if (isResponse(obj)) {
+    logFetchError(obj, logMessage);
+  } else {
+    logGenericError(obj, logMessage);
+  }
+}
+
+/**
+ * Log and display an error to the user. The detailed error can be viewed on the
+ * settings page under the 'logs' section.
+ * @param obj A FailedResponse object or some other value, typically an Error object
+ * @param msg A message to display to the user
+ * @param errorModal The function returned from 'useErrorModal'
+ * @param logMessage The function returned from 'useLogMessage'
+ */
+export function handleError(
+  obj: FailedResponse | any,
+  msg: string,
+  errorModal: ErrorModalFunction,
+  logMessage: LogMessage
+) {
+  logError(obj, logMessage);
+  if (isResponse(obj)) {
+    displayFetchError(obj, msg, errorModal);
+  } else {
+    displayGenericError(obj, msg, errorModal);
+  }
+}
+
+/**
+ * A React hook for 'logError'
+ */
+export const useLogError = () => {
+  const logMessage = useLogMessage();
+  return useCallback((obj: FailedResponse | any) => logError(obj, logMessage), [logMessage]);
+};
+
+/**
+ * A React hook for 'handleError'
+ */
+export const useHandleError = () => {
+  const errorModal = useErrorModal();
+  const logMessage = useLogMessage();
+  return useCallback(
+    (obj: FailedResponse | any, msg: string) => handleError(obj, msg, errorModal, logMessage),
+    [errorModal, logMessage]
+  );
+};
+
+/**
+ * The type of the function returned by 'useHandleError()'
+ */
+export type HandleError = (obj: FailedResponse | any, msg: string) => void;

--- a/src/hooks/useLogs.ts
+++ b/src/hooks/useLogs.ts
@@ -1,0 +1,10 @@
+import {useContext} from 'react';
+import {LogMessageContext, LogDataContext} from '../context/LogsProvider';
+
+export const useLogMessage = () => {
+  return useContext(LogMessageContext);
+};
+
+export const useLogs = () => {
+  return useContext(LogDataContext);
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import {LogsProvider} from './context/LogsProvider';
 import {ModalContextProvider} from './context/ModalContextProvider';
 import {SettingsProvider} from './context/SettingsProvider';
 // import reportWebVitals from './reportWebVitals';
@@ -22,7 +23,9 @@ root.render(
   <React.StrictMode>
     <ModalContextProvider>
       <SettingsProvider>
-        <App />
+        <LogsProvider>
+          <App />
+        </LogsProvider>
       </SettingsProvider>
     </ModalContextProvider>
   </React.StrictMode>

--- a/src/pages/Events/checkin.ts
+++ b/src/pages/Events/checkin.ts
@@ -5,12 +5,17 @@ import {playVibration} from '../../utils/haptics';
 import {playSound} from '../../utils/sound';
 import {handleError} from './sync';
 
+async function resetCheckedInLoading(participant: Participant) {
+  await db.participants.update(participant.id, {checkedInLoading: 0});
+}
+
 async function updateCheckinState(
   regform: Regform,
   participant: Participant,
   newCheckInState: boolean
 ) {
   return db.transaction('readwrite', db.regforms, db.participants, async () => {
+    await resetCheckedInLoading(participant);
     await db.participants.update(participant.id, {checkedIn: newCheckInState, checkedInLoading: 0});
     const slots = participant.occupiedSlots;
     const checkedInCount = regform.checkedInCount + (newCheckInState ? slots : -slots);
@@ -47,6 +52,7 @@ export async function checkIn(
       }
     }
   } else {
+    await resetCheckedInLoading(participant);
     handleError(response, 'Something went wrong when updating check-in status', errorModal);
   }
 }

--- a/src/pages/Events/checkin.ts
+++ b/src/pages/Events/checkin.ts
@@ -1,9 +1,8 @@
-import {ErrorModalFunction} from '../../context/ModalContextProvider';
 import db, {Event, Regform, Participant} from '../../db/db';
+import {HandleError} from '../../hooks/useError';
 import {checkInParticipant} from '../../utils/client';
 import {playVibration} from '../../utils/haptics';
 import {playSound} from '../../utils/sound';
-import {handleError} from './sync';
 
 async function resetCheckedInLoading(participant: Participant) {
   await db.participants.update(participant.id, {checkedInLoading: 0});
@@ -30,7 +29,7 @@ export async function checkIn(
   newCheckInState: boolean,
   sound: string,
   hapticFeedback: boolean,
-  errorModal: ErrorModalFunction
+  handleError: HandleError
 ) {
   await db.participants.update(participant.id, {checkedInLoading: 1});
   const response = await checkInParticipant(
@@ -53,6 +52,6 @@ export async function checkIn(
     }
   } else {
     await resetCheckedInLoading(participant);
-    handleError(response, 'Something went wrong when updating check-in status', errorModal);
+    handleError(response, 'Something went wrong when updating check-in status');
   }
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -75,7 +75,7 @@ function MainSettings() {
           selected={soundEffect}
           onChange={onSoundEffectChange}
         />
-        <SettingsToggle
+        <SettingToggle
           title="Haptic feedback"
           description="Vibrate on certain interactions (e.g. check-in, error etc.)"
           checked={hapticFeedback}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -134,6 +134,7 @@ function DebugSettings() {
 function LogSettings() {
   const {logs} = useLogs();
   const version = process.env.REACT_APP_VERSION!;
+  const isProduction = process.env.NODE_ENV === 'production';
 
   function onCopy() {
     const text = `App version: ${version}\n\nLogs:\n${formatLogs(logs)}`;
@@ -143,25 +144,27 @@ function LogSettings() {
   return (
     <div className="flex flex-col gap-6">
       <SettingsSection title="Logs">
-        <Setting title="Copy">
+        <Setting title="Copy to clipboard">
           <Button onClick={onCopy}>
             <DocumentDuplicateIcon className="h-5 min-w-[1.25rem]" />
           </Button>
         </Setting>
-        <div className="flex items-center justify-between gap-4">
-          {logs.length === 0 && <Typography variant="body2">No logs yet</Typography>}
-          {logs.length > 0 && (
-            <div className="flex max-h-[40vh] flex-col-reverse overflow-y-auto">
-              <code className="flex flex-col gap-2">
-                {logs.map((log, idx) => (
-                  <Typography key={idx} variant="body3" className="break-all">
-                    <LogEntry log={log} />
-                  </Typography>
-                ))}
-              </code>
-            </div>
-          )}
-        </div>
+        {!isProduction && (
+          <div className="flex items-center justify-between gap-4">
+            {logs.length === 0 && <Typography variant="body2">No logs available</Typography>}
+            {logs.length > 0 && (
+              <div className="flex max-h-[40vh] flex-col-reverse overflow-y-auto">
+                <code className="flex flex-col gap-2">
+                  {logs.map((log, idx) => (
+                    <Typography key={idx} variant="body3" className="break-all">
+                      <LogEntry log={log} />
+                    </Typography>
+                  ))}
+                </code>
+              </div>
+            )}
+          </div>
+        )}
       </SettingsSection>
     </div>
   );

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -94,7 +94,8 @@ function DebugSettings() {
   const confirmModal = useConfirmModal();
   const handleError = useHandleError();
 
-  async function resetDB() {
+  async function resetApp() {
+    localStorage.clear();
     try {
       await db.delete();
       await db.open();
@@ -117,7 +118,7 @@ function DebugSettings() {
                 title: 'Are you sure?',
                 content: 'This will permanently delete all application data',
                 confirmBtnText: 'Reset',
-                onConfirm: resetDB,
+                onConfirm: resetApp,
               });
             }}
           >

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -150,13 +150,15 @@ function LogSettings() {
         <div className="flex items-center justify-between gap-4">
           {logs.length === 0 && <Typography variant="body2">No logs yet</Typography>}
           {logs.length > 0 && (
-            <code className="max-h-[40vh] overflow-y-auto">
-              {logs.map((log, idx) => (
-                <Typography key={idx} variant="body3" className="break-all">
-                  <LogEntry log={log} />
-                </Typography>
-              ))}
-            </code>
+            <div className="flex max-h-[40vh] flex-col-reverse overflow-y-auto">
+              <code className="flex flex-col gap-2">
+                {logs.map((log, idx) => (
+                  <Typography key={idx} variant="body3" className="break-all">
+                    <LogEntry log={log} />
+                  </Typography>
+                ))}
+              </code>
+            </div>
           )}
         </div>
       </SettingsSection>

--- a/src/pages/event/EventPage.tsx
+++ b/src/pages/event/EventPage.tsx
@@ -15,6 +15,7 @@ import {
   useLiveEvent,
   useLiveRegforms,
 } from '../../db/db';
+import {useHandleError} from '../../hooks/useError';
 import {useConfirmModal, useErrorModal} from '../../hooks/useModal';
 import {formatDatetime} from '../../utils/date';
 import {wait} from '../../utils/wait';
@@ -54,7 +55,7 @@ function EventPageContent({
   regforms: Regform[];
 }) {
   const navigate = useNavigate();
-  const errorModal = useErrorModal();
+  const handleError = useHandleError();
 
   useEffect(() => {
     const controller = new AbortController();
@@ -65,16 +66,16 @@ function EventPageContent({
         return;
       }
 
-      await syncEvent(event, controller.signal, errorModal);
-      await syncRegforms(event, controller.signal, errorModal);
+      await syncEvent(event, controller.signal, handleError);
+      await syncRegforms(event, controller.signal, handleError);
     }
 
     sync().catch(err => {
-      errorModal({title: 'Something went wrong when fetching updates', content: err.message});
+      handleError(err, 'Something went wrong when fetching updates');
     });
 
     return () => controller.abort();
-  }, [eventId, errorModal]);
+  }, [eventId, handleError]);
 
   if (!event) {
     return <NotFoundBanner text="Event not found" icon={<CalendarDaysIcon />} />;

--- a/src/pages/home/Homepage.tsx
+++ b/src/pages/home/Homepage.tsx
@@ -11,7 +11,7 @@ import db, {
   useLiveRegforms,
   useLiveServers,
 } from '../../db/db';
-import {useErrorModal} from '../../hooks/useModal';
+import {useHandleError} from '../../hooks/useError';
 import {syncEvents} from '../Events/sync';
 import EventItem from './EventItem';
 
@@ -25,7 +25,7 @@ export default function Homepage() {
 }
 
 function HomepageContent() {
-  const errorModal = useErrorModal();
+  const handleError = useHandleError();
   const data = useLoaderData() as {
     servers: Server[];
     events: Event[];
@@ -40,14 +40,12 @@ function HomepageContent() {
 
     async function sync() {
       const events = await db.events.toArray();
-      await syncEvents(events, controller.signal, errorModal);
+      await syncEvents(events, controller.signal, handleError);
     }
 
-    sync().catch(err =>
-      errorModal({title: 'Something went wrong when updating events', content: err.message})
-    );
+    sync().catch(err => handleError(err, 'Something went wrong when updating events'));
     return () => controller.abort();
-  }, [errorModal]);
+  }, [handleError]);
 
   if (events.length === 0) {
     return <NoEventsBanner />;

--- a/src/pages/participant/ParticipantPage.tsx
+++ b/src/pages/participant/ParticipantPage.tsx
@@ -243,7 +243,7 @@ function ParticipantPageContent({
               text="Indico participant page"
               url={`${event.baseUrl}/event/${event.indicoId}/manage/registration/${regform.indicoId}/registrations/${participant.indicoId}`}
             />
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center justify-center gap-2">
               <RegistrationState state={participant.state} />
               {participant.price > 0 && (
                 <span

--- a/src/pages/participant/payment.tsx
+++ b/src/pages/participant/payment.tsx
@@ -2,10 +2,9 @@ import {ExclamationCircleIcon} from '@heroicons/react/20/solid';
 import {CheckIcon} from '@heroicons/react/24/outline';
 import {Button} from '../../Components/Tailwind';
 import {LoadingIndicator} from '../../Components/Tailwind/LoadingIndicator';
-import {ErrorModalFunction} from '../../context/ModalContextProvider';
 import db, {Event, Regform, Participant} from '../../db/db';
+import {HandleError} from '../../hooks/useError';
 import {togglePayment as _togglePayment} from '../../utils/client';
-import {handleError} from '../Events/sync';
 
 async function resetPaidLoading(participant: Participant) {
   await db.participants.update(participant.id, {isPaidLoading: 0});
@@ -15,18 +14,18 @@ async function markAsPaid(
   event: Event,
   regform: Regform,
   participant: Participant,
-  errorModal: ErrorModalFunction
+  handleError: HandleError
 ) {
-  return await togglePayment(event, regform, participant, true, errorModal);
+  return await togglePayment(event, regform, participant, true, handleError);
 }
 
 export async function markAsUnpaid(
   event: Event,
   regform: Regform,
   participant: Participant,
-  errorModal: ErrorModalFunction
+  handleError: HandleError
 ) {
-  return await togglePayment(event, regform, participant, false, errorModal);
+  return await togglePayment(event, regform, participant, false, handleError);
 }
 
 async function togglePayment(
@@ -34,7 +33,7 @@ async function togglePayment(
   regform: Regform,
   participant: Participant,
   paid: boolean,
-  errorModal: ErrorModalFunction
+  handleError: HandleError
 ) {
   await db.participants.update(participant.id, {isPaidLoading: 1});
   const response = await _togglePayment(
@@ -55,7 +54,7 @@ async function togglePayment(
     });
   } else {
     await resetPaidLoading(participant);
-    handleError(response, 'Something went wrong when updating payment status', errorModal);
+    handleError(response, 'Something went wrong when updating payment status');
   }
 }
 
@@ -63,15 +62,15 @@ export function PaymentWarning({
   event,
   regform,
   participant,
-  errorModal,
+  handleError,
 }: {
   event: Event;
   regform: Regform;
   participant: Participant;
-  errorModal: ErrorModalFunction;
+  handleError: HandleError;
 }) {
   const onClick = async () => {
-    await markAsPaid(event, regform, participant, errorModal);
+    await markAsPaid(event, regform, participant, handleError);
   };
 
   return (

--- a/src/pages/participant/payment.tsx
+++ b/src/pages/participant/payment.tsx
@@ -7,6 +7,10 @@ import db, {Event, Regform, Participant} from '../../db/db';
 import {togglePayment as _togglePayment} from '../../utils/client';
 import {handleError} from '../Events/sync';
 
+async function resetPaidLoading(participant: Participant) {
+  await db.participants.update(participant.id, {isPaidLoading: 0});
+}
+
 async function markAsPaid(
   event: Event,
   regform: Regform,
@@ -50,6 +54,7 @@ async function togglePayment(
       isPaidLoading: 0,
     });
   } else {
+    await resetPaidLoading(participant);
     handleError(response, 'Something went wrong when updating payment status', errorModal);
   }
 }

--- a/src/pages/regform/RegformPage.tsx
+++ b/src/pages/regform/RegformPage.tsx
@@ -24,6 +24,7 @@ import {
   useLiveParticipants,
   useLiveRegform,
 } from '../../db/db';
+import {useHandleError} from '../../hooks/useError';
 import {useConfirmModal, useErrorModal} from '../../hooks/useModal';
 import {wait} from '../../utils/wait';
 import {syncEvent, syncParticipants, syncRegform} from '../Events/sync';
@@ -82,7 +83,7 @@ function RegformPageContent({
   participantCount: number;
 }) {
   const navigate = useNavigate();
-  const errorModal = useErrorModal();
+  const handleError = useHandleError();
   const [isSyncing, setIsSyncing] = useState(false);
   const savedFilters = JSON.parse(localStorage.getItem('regforms') || '{}')[regformId];
   const [searchData, _setSearchData] = useState({
@@ -106,9 +107,9 @@ function RegformPageContent({
         return;
       }
 
-      await syncEvent(event, controller.signal, errorModal);
-      await syncRegform(event, regform, controller.signal, errorModal);
-      await syncParticipants(event, regform, controller.signal, errorModal);
+      await syncEvent(event, controller.signal, handleError);
+      await syncRegform(event, regform, controller.signal, handleError);
+      await syncParticipants(event, regform, controller.signal, handleError);
     }
 
     async function sync() {
@@ -116,7 +117,7 @@ function RegformPageContent({
       try {
         await _sync();
       } catch (err: any) {
-        errorModal({title: 'Something went wrong when fetching updates', content: err.message});
+        handleError(err, 'Something went wrong when fetching updates');
       } finally {
         if (!controller.signal.aborted) {
           setIsSyncing(false);
@@ -126,7 +127,7 @@ function RegformPageContent({
 
     sync();
     return () => controller.abort();
-  }, [eventId, regformId, errorModal]);
+  }, [eventId, regformId, handleError]);
 
   if (!event) {
     return <NotFoundBanner text="Event not found" icon={<CalendarDaysIcon />} />;

--- a/src/pages/scan/Scan.tsx
+++ b/src/pages/scan/Scan.tsx
@@ -8,6 +8,7 @@ import QrScannerPlugin, {
 import {Typography} from '../../Components/Tailwind';
 import LoadingBanner from '../../Components/Tailwind/LoadingBanner';
 import TopNav from '../../Components/TopNav';
+import {useHandleError} from '../../hooks/useError';
 import {useMediaQuery} from '../../hooks/useMediaQuery';
 import {useErrorModal} from '../../hooks/useModal';
 import useSettings from '../../hooks/useSettings';
@@ -22,6 +23,7 @@ export default function ScanPage() {
   const {autoCheckin} = useSettings();
   const navigate = useNavigate();
   const errorModal = useErrorModal();
+  const handleError = useHandleError();
   const offline = useIsOffline();
   const isDesktop = useMediaQuery('(min-width: 1280px)');
 
@@ -36,7 +38,7 @@ export default function ScanPage() {
     try {
       scannedData = JSON.parse(decodedText);
     } catch (e: any) {
-      errorModal({title: 'Error parsing the QRCode data', content: e.message});
+      handleError(e, 'Error parsing the QRCode data');
       return;
     }
 
@@ -53,7 +55,7 @@ export default function ScanPage() {
       try {
         await handleEvent(scannedData, errorModal, navigate);
       } catch (e: any) {
-        errorModal({title: 'Error processing QR code', content: e.message});
+        handleError(e, 'Error processing QR code');
       }
       return;
     }
@@ -61,9 +63,9 @@ export default function ScanPage() {
     const parsedData = parseQRCodeParticipantData(scannedData);
     if (parsedData) {
       try {
-        await handleParticipant(parsedData, errorModal, navigate, autoCheckin);
+        await handleParticipant(parsedData, errorModal, handleError, navigate, autoCheckin);
       } catch (e: any) {
-        errorModal({title: 'Error processing QR code', content: e.message});
+        handleError(e, 'Error processing QR code');
       }
     } else {
       errorModal({
@@ -77,7 +79,7 @@ export default function ScanPage() {
     try {
       await processCode(decodedText);
     } catch (e: any) {
-      errorModal({title: 'Error processing QR code', content: e.message});
+      handleError(e, 'Error processing QR code');
     } finally {
       setProcessing(false);
     }

--- a/src/pages/scan/scan.test.ts
+++ b/src/pages/scan/scan.test.ts
@@ -98,6 +98,32 @@ describe('test handleParticipant()', () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
+  test('test existing participant with missing event', async () => {
+    await createDummyServer();
+    await createDummyEvent();
+    await createDummyParticipant();
+    const data = {
+      serverUrl: dummyServer.baseUrl,
+      checkinSecret: dummyParticipant.checkinSecret,
+    } as any;
+    const errorModal = jest.fn();
+    const handleError = jest.fn();
+    const navigate = jest.fn();
+
+    (getParticipantByUuid as any).mockResolvedValue({
+      ok: true,
+      data: {id: 101, eventId: 9999, regformId: 9999, checkinSecret: '1234'},
+    });
+    await expect(
+      handleParticipant(data, errorModal, handleError, navigate, true)
+    ).resolves.not.toThrow();
+    expect(errorModal).toHaveBeenCalledWith({
+      title: 'The event of this participant does not exist',
+      content: 'Scan an event QR code first and try again.',
+    });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
   test('test existing participant with missing regform', async () => {
     await createDummyServer();
     await createDummyEvent();
@@ -105,13 +131,15 @@ describe('test handleParticipant()', () => {
     const data = {
       serverUrl: dummyServer.baseUrl,
       checkinSecret: dummyParticipant.checkinSecret,
-      id: 101,
-      eventId: 42,
-      regformId: 9999,
     } as any;
     const errorModal = jest.fn();
     const handleError = jest.fn();
     const navigate = jest.fn();
+
+    (getParticipantByUuid as any).mockResolvedValue({
+      ok: true,
+      data: {id: 101, eventId: 42, regformId: 9999, checkinSecret: '1234'},
+    });
     await expect(
       handleParticipant(data, errorModal, handleError, navigate, true)
     ).resolves.not.toThrow();
@@ -130,13 +158,15 @@ describe('test handleParticipant()', () => {
     const data = {
       serverUrl: dummyServer.baseUrl,
       checkinSecret: dummyParticipant.checkinSecret,
-      id: 101,
-      eventId: 42,
-      regformId: 73,
     } as any;
     const errorModal = jest.fn();
     const handleError = jest.fn();
     const navigate = jest.fn();
+
+    (getParticipantByUuid as any).mockResolvedValue({
+      ok: true,
+      data: {id: 101, eventId: 42, regformId: 73, checkinSecret: '1234'},
+    });
     expect(errorModal).not.toHaveBeenCalled();
     await expect(
       handleParticipant(data, errorModal, handleError, navigate, true)

--- a/src/pages/scan/scan.test.ts
+++ b/src/pages/scan/scan.test.ts
@@ -85,9 +85,12 @@ describe('test handleParticipant()', () => {
   test('test missing server', async () => {
     const data = {serverUrl: ''} as any;
     const errorModal = jest.fn();
+    const handleError = jest.fn();
     const navigate = jest.fn();
 
-    await expect(handleParticipant(data, errorModal, navigate, true)).resolves.not.toThrow();
+    await expect(
+      handleParticipant(data, errorModal, handleError, navigate, true)
+    ).resolves.not.toThrow();
     expect(errorModal).toHaveBeenCalledWith({
       title: 'The server of this participant does not exist',
       content: 'Scan an event QR code first and try again.',
@@ -102,14 +105,16 @@ describe('test handleParticipant()', () => {
     const data = {
       serverUrl: dummyServer.baseUrl,
       checkinSecret: dummyParticipant.checkinSecret,
+      id: 101,
+      eventId: 42,
+      regformId: 9999,
     } as any;
     const errorModal = jest.fn();
+    const handleError = jest.fn();
     const navigate = jest.fn();
-    (getParticipantByUuid as any).mockResolvedValue({
-      ok: true,
-      data: {id: 101, eventId: 42, regformId: 9999, checkinSecret: dummyParticipant.checkinSecret},
-    });
-    await expect(handleParticipant(data, errorModal, navigate, true)).resolves.not.toThrow();
+    await expect(
+      handleParticipant(data, errorModal, handleError, navigate, true)
+    ).resolves.not.toThrow();
     expect(errorModal).toHaveBeenCalledWith({
       title: 'The registration form of this participant does not exist',
       content: 'Scan an event QR code first and try again.',
@@ -125,14 +130,17 @@ describe('test handleParticipant()', () => {
     const data = {
       serverUrl: dummyServer.baseUrl,
       checkinSecret: dummyParticipant.checkinSecret,
+      id: 101,
+      eventId: 42,
+      regformId: 73,
     } as any;
     const errorModal = jest.fn();
+    const handleError = jest.fn();
     const navigate = jest.fn();
-    (getParticipantByUuid as any).mockResolvedValue({
-      ok: true,
-      data: {id: 101, eventId: 42, regformId: 73, checkinSecret: dummyParticipant.checkinSecret},
-    });
-    await expect(handleParticipant(data, errorModal, navigate, true)).resolves.not.toThrow();
+    expect(errorModal).not.toHaveBeenCalled();
+    await expect(
+      handleParticipant(data, errorModal, handleError, navigate, true)
+    ).resolves.not.toThrow();
     expect(errorModal).not.toHaveBeenCalled();
     expect(navigate.mock.calls).toHaveLength(1);
     expect(navigate).toHaveBeenCalledWith('/event/1/1/1', {
@@ -150,18 +158,24 @@ describe('test handleParticipant()', () => {
       checkinSecret: '1234',
     } as any;
     const errorModal = jest.fn();
+    const handleError = jest.fn();
     const navigate = jest.fn();
 
     (getParticipantByUuid as any).mockResolvedValue({
       ok: false,
       status: 404,
     });
-    await expect(handleParticipant(data, errorModal, navigate, true)).resolves.not.toThrow();
+    await expect(
+      handleParticipant(data, errorModal, handleError, navigate, true)
+    ).resolves.not.toThrow();
 
-    expect(errorModal).toHaveBeenCalledWith({
-      title: 'Could not fetch participant data',
-      content: 'Response status: 404',
-    });
+    expect(handleError).toHaveBeenCalledWith(
+      {
+        ok: false,
+        status: 404,
+      },
+      'Could not fetch participant data'
+    );
     expect(navigate).not.toHaveBeenCalled();
   });
 
@@ -174,13 +188,16 @@ describe('test handleParticipant()', () => {
       checkinSecret: '1234',
     } as any;
     const errorModal = jest.fn();
+    const handleError = jest.fn();
     const navigate = jest.fn();
 
     (getParticipantByUuid as any).mockResolvedValue({
       ok: true,
       data: {id: 101, eventId: 9999, regformId: 73, checkinSecret: '1234'},
     });
-    await expect(handleParticipant(data, errorModal, navigate, true)).resolves.not.toThrow();
+    await expect(
+      handleParticipant(data, errorModal, handleError, navigate, true)
+    ).resolves.not.toThrow();
 
     expect(errorModal).toHaveBeenCalledWith({
       title: 'The event of this participant does not exist',
@@ -198,13 +215,16 @@ describe('test handleParticipant()', () => {
       checkinSecret: '1234',
     } as any;
     const errorModal = jest.fn();
+    const handleError = jest.fn();
     const navigate = jest.fn();
 
     (getParticipantByUuid as any).mockResolvedValue({
       ok: true,
       data: {id: 101, eventId: 42, regformId: 9999, checkinSecret: '1234'},
     });
-    await expect(handleParticipant(data, errorModal, navigate, true)).resolves.not.toThrow();
+    await expect(
+      handleParticipant(data, errorModal, handleError, navigate, true)
+    ).resolves.not.toThrow();
 
     expect(errorModal).toHaveBeenCalledWith({
       title: 'The registration form of this participant does not exist',
@@ -222,13 +242,16 @@ describe('test handleParticipant()', () => {
       checkinSecret: '1234',
     } as any;
     const errorModal = jest.fn();
+    const handleError = jest.fn();
     const navigate = jest.fn();
 
     (getParticipantByUuid as any).mockResolvedValue({
       ok: true,
       data: {id: 101, eventId: 42, regformId: 73, checkinSecret: '1234'},
     });
-    await expect(handleParticipant(data, errorModal, navigate, true)).resolves.not.toThrow();
+    await expect(
+      handleParticipant(data, errorModal, handleError, navigate, true)
+    ).resolves.not.toThrow();
 
     const participant = await db.participants.get(1);
     expect(participant).toEqual({

--- a/src/pages/scan/scan.ts
+++ b/src/pages/scan/scan.ts
@@ -8,10 +8,10 @@ import db, {
   getServer,
   updateParticipant,
 } from '../../db/db';
+import {HandleError} from '../../hooks/useError';
 import {getParticipantByUuid as getParticipant} from '../../utils/client';
 import {discoveryEndpoint, redirectUri} from '../Auth/utils';
 import {QRCodeEventData, QRCodeParticipantData} from '../Auth/utils';
-import {handleError} from '../Events/sync';
 
 async function startOAuthFlow(data: QRCodeEventData, errorModal: ErrorModalFunction) {
   const {
@@ -79,6 +79,7 @@ export async function handleEvent(
 export async function handleParticipant(
   data: QRCodeParticipantData,
   errorModal: ErrorModalFunction,
+  handleError: HandleError,
   navigate: NavigateFunction,
   autoCheckin: boolean
 ) {
@@ -133,6 +134,6 @@ export async function handleParticipant(
       state: {autoCheckin, fromScan: true},
     });
   } else {
-    handleError(response, 'Could not fetch participant data', errorModal);
+    handleError(response, 'Could not fetch participant data');
   }
 }


### PR DESCRIPTION
Closes #41 

The branch is deployed here: https://indico-checkin-test.app.cern.ch

Adds more capabilities to debug and to fix issues with the app.

- Users can now manually reset the database. This option will be useful in case something goes wrong and the db gets into an inconsistent state.
- The app now logs both JS errors and `fetch` errors. The error log can be viewed on the settings page. There's a button to copy all logs including the app version which makes it easy to share the logs for debugging purposes.

![image](https://github.com/indico/indico-checkin-pwa/assets/8739637/be74edad-bae7-4566-aff6-fc62f5f3e11a)
![image](https://github.com/indico/indico-checkin-pwa/assets/8739637/5725e1b9-7a9c-4a20-89b1-351f46d37b22)
