### PR TITLE
Add Torch/Flashlight support

### DIFF
--- a/src/Components/QrScanner/QrScannerPlugin.tsx
+++ b/src/Components/QrScanner/QrScannerPlugin.tsx
@@ -54,6 +54,18 @@ export default function QrScannerPlugin({
   const html5CustomScanner: MutableRefObject<Html5Qrcode | null> = useRef(null);
   const [canUseCamera, setCanUseCamera] = useState(true);
 
+  // Turn off the torch (if it is on) when navigating away from the scan page
+  async function switchOffTorch(html5CustomScanner: MutableRefObject<Html5Qrcode | null>) {
+    try {
+      const track = html5CustomScanner?.current?.getRunningTrackCameraCapabilities();
+      if (track && track.torchFeature().value()) {
+        await track.torchFeature().apply(false);
+      }
+    } catch (error) {
+      console.warn('Failed to disable torch:', error);
+    }
+  }
+
   useEffect(() => {
     const showQRCode = async () => {
       const hasCamPerm: boolean = await checkCameraPermissions();
@@ -86,6 +98,7 @@ export default function QrScannerPlugin({
     return () => {
       const stopQrScanner = async () => {
         if (html5CustomScanner.current?.isScanning) {
+          switchOffTorch(html5CustomScanner);
           await html5CustomScanner.current.stop();
         }
         html5CustomScanner.current?.clear();

--- a/src/Components/QrScanner/QrScannerPlugin.tsx
+++ b/src/Components/QrScanner/QrScannerPlugin.tsx
@@ -1,8 +1,9 @@
 // file = QrScannerPlugin.jsx
-import {MutableRefObject, useEffect, useRef, useState} from 'react';
-import {ArrowUpTrayIcon, BoltIcon, BoltSlashIcon} from '@heroicons/react/24/solid';
+import {MutableRefObject, useEffect, useRef} from 'react';
+import {ArrowUpTrayIcon} from '@heroicons/react/24/solid';
 import {Html5Qrcode, Html5QrcodeScannerState, Html5QrcodeSupportedFormats} from 'html5-qrcode';
 import {checkCameraPermissions} from '../../utils/media';
+import {TorchButton} from './TorchButton';
 import classes from './QrScanner.module.css';
 
 // Id of the HTML element used by the Html5QrcodeScanner.
@@ -51,8 +52,6 @@ export default function QrScannerPlugin({
 }: QrProps) {
   const aspectRatio = calcAspectRatio();
   const html5CustomScanner: MutableRefObject<Html5Qrcode | null> = useRef(null);
-  const torchStateRef = useRef(false);
-  const [, setRender] = useState(false); // TODO: Find a better way to force a re-render without using the state (this causes the camera to reload)
 
   useEffect(() => {
     const showQRCode = async () => {
@@ -105,26 +104,13 @@ export default function QrScannerPlugin({
     onPermRefused,
   ]);
 
-  const toggleTorch = async () => {
-    try {
-      const track = html5CustomScanner.current?.getRunningTrackCameraCapabilities();
-      if (track && track.torchFeature().isSupported()) {
-        torchStateRef.current = !torchStateRef.current;
-        await track.torchFeature().apply(torchStateRef.current);
-        setRender(prev => !prev); // TODO: Hacky
-      }
-    } catch (error) {
-      console.warn('Error toggling torch:', error);
-    }
-  };
-
   return (
     <>
       <div className={classes.wrapper}>
         <ShadedRegion size={qrbox}></ShadedRegion>
         <div id={qrcodeRegionId} />
       </div>
-      <ToggleTorchButton onClick={toggleTorch} toggled={!torchStateRef.current} />
+      <TorchButton html5CustomScanner={html5CustomScanner} />
     </>
   );
 }
@@ -151,21 +137,6 @@ export function FileUploadScanner({
         <span>Upload QR code image</span>
       </label>
       <div id={qrcodeFileRegionId}></div>
-    </div>
-  );
-}
-
-export function ToggleTorchButton({onClick, toggled}: {onClick: () => void; toggled: boolean}) {
-  // TODO: Hide away the button when the torch is not supported
-  return (
-    <div className="mt-4 flex justify-center">
-      <div onClick={onClick} className="inline-flex rounded-full bg-primary text-white">
-        {toggled ? (
-          <BoltIcon className="mx-2 my-2 h-16 w-16" />
-        ) : (
-          <BoltSlashIcon className="mx-2 my-2 h-16 w-16" />
-        )}
-      </div>
     </div>
   );
 }

--- a/src/Components/QrScanner/QrScannerPlugin.tsx
+++ b/src/Components/QrScanner/QrScannerPlugin.tsx
@@ -1,5 +1,5 @@
 // file = QrScannerPlugin.jsx
-import {MutableRefObject, useEffect, useRef} from 'react';
+import {MutableRefObject, useEffect, useRef, useState} from 'react';
 import {ArrowUpTrayIcon} from '@heroicons/react/24/solid';
 import {Html5Qrcode, Html5QrcodeScannerState, Html5QrcodeSupportedFormats} from 'html5-qrcode';
 import {checkCameraPermissions} from '../../utils/media';
@@ -52,12 +52,14 @@ export default function QrScannerPlugin({
 }: QrProps) {
   const aspectRatio = calcAspectRatio();
   const html5CustomScanner: MutableRefObject<Html5Qrcode | null> = useRef(null);
+  const [canUseCamera, setCanUseCamera] = useState(true);
 
   useEffect(() => {
     const showQRCode = async () => {
       const hasCamPerm: boolean = await checkCameraPermissions();
       if (!hasCamPerm) {
         onPermRefused();
+        setCanUseCamera(false);
         return;
       }
 
@@ -110,7 +112,7 @@ export default function QrScannerPlugin({
         <ShadedRegion size={qrbox}></ShadedRegion>
         <div id={qrcodeRegionId} />
       </div>
-      <TorchButton html5CustomScanner={html5CustomScanner} />
+      <TorchButton html5CustomScanner={html5CustomScanner} canUseCamera={canUseCamera} />
     </>
   );
 }

--- a/src/Components/QrScanner/TorchButton.tsx
+++ b/src/Components/QrScanner/TorchButton.tsx
@@ -32,7 +32,7 @@ export function TorchButton({html5CustomScanner, canUseCamera}: TorchButtonProps
   }, [torchOn, html5CustomScanner]);
 
   if (!canUseCamera) {
-    return null;
+    return;
   }
 
   if (torchUnavailable) {
@@ -60,9 +60,9 @@ export function TorchButton({html5CustomScanner, canUseCamera}: TorchButtonProps
         className="inline-flex cursor-pointer rounded-full bg-primary text-white"
       >
         {torchOn ? (
-          <BoltIcon className="mx-2 my-2 h-16 w-16" />
-        ) : (
           <BoltSlashIcon className="mx-2 my-2 h-16 w-16" />
+        ) : (
+          <BoltIcon className="mx-2 my-2 h-16 w-16" />
         )}
       </div>
     </div>

--- a/src/Components/QrScanner/TorchButton.tsx
+++ b/src/Components/QrScanner/TorchButton.tsx
@@ -1,0 +1,46 @@
+import {MutableRefObject, useState, useEffect} from 'react';
+import {BoltIcon, BoltSlashIcon} from '@heroicons/react/24/solid';
+import {Html5Qrcode} from 'html5-qrcode';
+import PropTypes from 'prop-types';
+
+interface TorchButtonProps {
+  html5CustomScanner: MutableRefObject<Html5Qrcode | null>;
+}
+
+export function TorchButton({html5CustomScanner}: TorchButtonProps) {
+  const [torchOn, setTorchOn] = useState(false);
+
+  useEffect(() => {
+    const toggleTorch = async () => {
+      try {
+        const track = html5CustomScanner?.current?.getRunningTrackCameraCapabilities();
+        if (track && track.torchFeature().isSupported()) {
+          await track.torchFeature().apply(torchOn);
+        }
+      } catch (error) {
+        console.warn('Failed to toggle torch:', error);
+      }
+    };
+
+    toggleTorch();
+  }, [torchOn, html5CustomScanner]);
+
+  return (
+    <div className="mt-4 flex justify-center">
+      <div
+        onClick={() => setTorchOn(prev => !prev)}
+        className="inline-flex cursor-pointer rounded-full bg-primary text-white"
+      >
+        {torchOn ? (
+          <BoltIcon className="mx-2 my-2 h-16 w-16" />
+        ) : (
+          <BoltSlashIcon className="mx-2 my-2 h-16 w-16" />
+        )}
+      </div>
+    </div>
+  );
+}
+
+TorchButton.propTypes = {
+  html5CustomScanner: PropTypes.object.isRequired,
+};

--- a/src/Components/QrScanner/TorchButton.tsx
+++ b/src/Components/QrScanner/TorchButton.tsx
@@ -1,14 +1,16 @@
 import {MutableRefObject, useState, useEffect} from 'react';
-import {BoltIcon, BoltSlashIcon} from '@heroicons/react/24/solid';
+import {BoltIcon, BoltSlashIcon, ExclamationCircleIcon} from '@heroicons/react/24/solid';
 import {Html5Qrcode} from 'html5-qrcode';
 import PropTypes from 'prop-types';
 
 interface TorchButtonProps {
   html5CustomScanner: MutableRefObject<Html5Qrcode | null>;
+  canUseCamera: boolean;
 }
 
-export function TorchButton({html5CustomScanner}: TorchButtonProps) {
+export function TorchButton({html5CustomScanner, canUseCamera}: TorchButtonProps) {
   const [torchOn, setTorchOn] = useState(false);
+  const [torchUnavailable, setTorchUnavailable] = useState(false);
 
   useEffect(() => {
     const toggleTorch = async () => {
@@ -16,14 +18,40 @@ export function TorchButton({html5CustomScanner}: TorchButtonProps) {
         const track = html5CustomScanner?.current?.getRunningTrackCameraCapabilities();
         if (track && track.torchFeature().isSupported()) {
           await track.torchFeature().apply(torchOn);
+        } else if (track && !track.torchFeature().isSupported()) {
+          setTorchUnavailable(true);
+          console.warn('Torch feature is not supported on this device.');
         }
       } catch (error) {
+        setTorchUnavailable(true);
         console.warn('Failed to toggle torch:', error);
       }
     };
 
     toggleTorch();
   }, [torchOn, html5CustomScanner]);
+
+  if (!canUseCamera) {
+    return null;
+  }
+
+  if (torchUnavailable) {
+    return (
+      <>
+        <div className="fit-content flex justify-center gap-1 bg-yellow-500 py-3 text-center text-amber-900">
+          <span className="flex items-center">
+            <ExclamationCircleIcon className="mr-1 h-6 w-6" />
+            Your device's torch is unavailable
+          </span>
+        </div>
+        <div className="mt-4 flex justify-center">
+          <div className="inline-flex cursor-not-allowed rounded-full bg-gray-200 text-gray-500">
+            <BoltSlashIcon className="mx-2 my-2 h-16 w-16" />
+          </div>
+        </div>
+      </>
+    );
+  }
 
   return (
     <div className="mt-4 flex justify-center">
@@ -43,4 +71,5 @@ export function TorchButton({html5CustomScanner}: TorchButtonProps) {
 
 TorchButton.propTypes = {
   html5CustomScanner: PropTypes.object.isRequired,
+  canUseCamera: PropTypes.bool.isRequired,
 };

--- a/src/Components/QrScanner/TorchButton.tsx
+++ b/src/Components/QrScanner/TorchButton.tsx
@@ -2,6 +2,7 @@ import {MutableRefObject, useState, useEffect} from 'react';
 import {BoltIcon, BoltSlashIcon, ExclamationCircleIcon} from '@heroicons/react/24/solid';
 import {Html5Qrcode} from 'html5-qrcode';
 import PropTypes from 'prop-types';
+import {useLogError} from '../../hooks/useError';
 
 interface TorchButtonProps {
   html5CustomScanner: MutableRefObject<Html5Qrcode | null>;
@@ -11,6 +12,7 @@ interface TorchButtonProps {
 export function TorchButton({html5CustomScanner, canUseCamera}: TorchButtonProps) {
   const [torchOn, setTorchOn] = useState(false);
   const [torchUnavailable, setTorchUnavailable] = useState(false);
+  const logError = useLogError();
 
   useEffect(() => {
     const toggleTorch = async () => {
@@ -25,11 +27,12 @@ export function TorchButton({html5CustomScanner, canUseCamera}: TorchButtonProps
       } catch (error) {
         setTorchUnavailable(true);
         console.warn('Failed to toggle torch:', error);
+        logError(`Failed to toggle torch: ${error}`);
       }
     };
 
     toggleTorch();
-  }, [torchOn, html5CustomScanner]);
+  }, [torchOn, html5CustomScanner, logError]);
 
   if (!canUseCamera) {
     return;
@@ -37,21 +40,19 @@ export function TorchButton({html5CustomScanner, canUseCamera}: TorchButtonProps
 
   if (torchUnavailable) {
     return (
-      <>
-        <div className="fit-content flex justify-center gap-1 bg-yellow-500 py-3 text-center text-amber-900">
-          <span className="flex items-center">
-            <ExclamationCircleIcon className="mr-1 h-6 w-6" />
-            Your device's torch is unavailable
-          </span>
-        </div>
-      </>
+      <div className="fit-content flex justify-center gap-1 bg-yellow-500 py-3 text-center text-amber-900">
+        <span className="flex items-center">
+          <ExclamationCircleIcon className="mr-1 h-6 w-6" />
+          Your device's torch is unavailable
+        </span>
+      </div>
     );
   }
 
   return (
     <div
       onClick={() => setTorchOn(prev => !prev)}
-      className="fit-content flex justify-center gap-1 bg-primary py-3 text-center text-white"
+      className="fit-content flex justify-center gap-1 bg-primary py-3 text-center text-white active:bg-blue-800 dark:bg-blue-600 dark:active:bg-blue-700"
     >
       <span className="flex items-center">
         {torchOn ? (

--- a/src/Components/QrScanner/TorchButton.tsx
+++ b/src/Components/QrScanner/TorchButton.tsx
@@ -44,27 +44,28 @@ export function TorchButton({html5CustomScanner, canUseCamera}: TorchButtonProps
             Your device's torch is unavailable
           </span>
         </div>
-        <div className="mt-4 flex justify-center">
-          <div className="inline-flex cursor-not-allowed rounded-full bg-gray-200 text-gray-500">
-            <BoltSlashIcon className="mx-2 my-2 h-16 w-16" />
-          </div>
-        </div>
       </>
     );
   }
 
   return (
-    <div className="mt-4 flex justify-center">
-      <div
-        onClick={() => setTorchOn(prev => !prev)}
-        className="inline-flex cursor-pointer rounded-full bg-primary text-white"
-      >
+    <div
+      onClick={() => setTorchOn(prev => !prev)}
+      className="fit-content flex justify-center gap-1 bg-primary py-3 text-center text-white"
+    >
+      <span className="flex items-center">
         {torchOn ? (
-          <BoltSlashIcon className="mx-2 my-2 h-16 w-16" />
+          <>
+            <BoltSlashIcon className="mr-1 h-6 w-6" />
+            Turn torch off
+          </>
         ) : (
-          <BoltIcon className="mx-2 my-2 h-16 w-16" />
+          <>
+            <BoltIcon className="mr-1 h-6 w-6" />
+            Turn torch on
+          </>
         )}
-      </div>
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
This PR allows (supported) devices to toggle the camera torch/flashlight when on the check-in scanner page (for low-light conditions).

TODO:
- [x] Fix state usage (otherwise this causes the camera to reload after toggling the torch which isn't great)
- [x] Hide away the torch toggle button when the device doesn't support it
- [x] Switch off the torch (if enabled) after navigating away from the scan page