### PR TITLE
Add support for image fields and personal picture display

### DIFF
--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -100,6 +100,7 @@ export interface Participant extends _Participant {
   deleted: IDBBoolean;
   notes: string;
   isPaidLoading: IDBBoolean; // 1 (true) while the request to mark as (un)paid is in progress
+  personalDataPicture?: string;
 }
 
 interface AddParticipant extends _Participant {

--- a/src/pages/participant/ParticipantPage.tsx
+++ b/src/pages/participant/ParticipantPage.tsx
@@ -237,7 +237,15 @@ function ParticipantPageContent({
       <div className="px-4">
         <div className="mt-2 flex flex-col gap-4">
           <div className="flex flex-col items-center gap-2 px-4">
-            <UserIcon className="w-16 text-blue-600 dark:text-blue-700" />
+            {participant.personalDataPicture ? (
+              <img
+                src={participant.personalDataPicture}
+                alt="Personal data"
+                className="h-32 w-32 rounded-full shadow-lg"
+              />
+            ) : (
+              <UserIcon className="w-16 text-blue-600 dark:text-blue-700" />
+            )}
             <Title title={participant.fullName} />
             <IndicoLink
               text="Indico participant page"

--- a/src/pages/participant/fields.tsx
+++ b/src/pages/participant/fields.tsx
@@ -63,6 +63,8 @@ export function Field(field: FieldProps) {
       return <AccommodationField {...(field as ChoiceFieldProps)} />;
     case 'accompanying_persons':
       return <AccompanyingPersonsField {...field} />;
+    case 'picture':
+      return <PictureField {...field} />;
     default:
       console.warn('Unhandled field', field);
       return null;
@@ -278,4 +280,16 @@ export function getAccompanyingPersons(sections: Section[]) {
     }
   }
   return persons;
+}
+
+function PictureField({title, description, data}: FieldProps) {
+  if (!data) {
+    return;
+  }
+  return (
+    <div>
+      <FieldHeader title={title} description={description} />
+      <img src={data} alt={title} />
+    </div>
+  );
 }


### PR DESCRIPTION
This PR adds support for image fields in the regform, as well as displaying the image field used in the personal data regform as the users' profile photo on the registrant page of the PWA.

![image](https://github.com/user-attachments/assets/453cb419-7bcf-4de0-b36b-95114678eb59)
