### PR TITLE
Add settings to require registration completion before check-in 

### DIFF
--- a/src/Components/Tailwind/Table.tsx
+++ b/src/Components/Tailwind/Table.tsx
@@ -284,7 +284,7 @@ function Row({fullName, checkedIn, state, onClick, isEven}: RowProps) {
             {fullName}
           </Typography>
           <div className="flex">
-            {state === 'pending' && <ExclamationCircleIcon className="h-6 w-6 text-yellow-500" />}
+            {state === 'pending' && <ClockIcon className="h-6 w-6 text-yellow-500" />}
             {state === 'unpaid' && <BanknotesIcon className="h-6 w-6 text-yellow-500" />}
             {state === 'withdrawn' && <ArrowUturnLeftIcon className="h-6 w-6 text-red-500" />}
             {state === 'rejected' && <XCircleIcon className="h-6 w-6 text-red-500" />}

--- a/src/Components/Tailwind/Table.tsx
+++ b/src/Components/Tailwind/Table.tsx
@@ -273,7 +273,14 @@ function Row({fullName, checkedIn, state, onClick, isEven}: RowProps) {
     >
       <td className="max-w-0 p-4">
         <div className="flex items-center justify-between">
-          <Typography variant="body1" className={fullNameClass}>
+          <Typography
+            variant="body1"
+            className={
+              state === 'rejected' || state === 'withdrawn'
+                ? `${fullNameClass} line-through`
+                : fullNameClass
+            }
+          >
             {fullName}
           </Typography>
           <div className="flex">

--- a/src/Components/Tailwind/Table.tsx
+++ b/src/Components/Tailwind/Table.tsx
@@ -1,11 +1,13 @@
 import {ChangeEvent, KeyboardEvent, useState, useMemo, useRef, useEffect, forwardRef} from 'react';
 import {
   ArrowSmallLeftIcon,
+  ArrowUturnLeftIcon,
   BanknotesIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
   MagnifyingGlassIcon,
   UserGroupIcon,
+  XCircleIcon,
   XMarkIcon,
 } from '@heroicons/react/20/solid';
 import {Participant, RegistrationTag} from '../../db/db';
@@ -271,19 +273,14 @@ function Row({fullName, checkedIn, state, onClick, isEven}: RowProps) {
     >
       <td className="max-w-0 p-4">
         <div className="flex items-center justify-between">
-          <Typography
-            variant="body1"
-            className={
-              state === 'rejected' || state === 'withdrawn'
-                ? `${fullNameClass} line-through`
-                : fullNameClass
-            }
-          >
+          <Typography variant="body1" className={fullNameClass}>
             {fullName}
           </Typography>
           <div className="flex">
             {state === 'pending' && <ExclamationCircleIcon className="h-6 w-6 text-yellow-500" />}
             {state === 'unpaid' && <BanknotesIcon className="h-6 w-6 text-yellow-500" />}
+            {state === 'withdrawn' && <ArrowUturnLeftIcon className="h-6 w-6 text-red-500" />}
+            {state === 'rejected' && <XCircleIcon className="h-6 w-6 text-red-500" />}
             {checkedIn && <CheckCircleIcon className="h-6 w-6 text-green-500" />}
           </div>
         </div>

--- a/src/Components/Tailwind/Table.tsx
+++ b/src/Components/Tailwind/Table.tsx
@@ -4,7 +4,7 @@ import {
   ArrowUturnLeftIcon,
   BanknotesIcon,
   CheckCircleIcon,
-  ExclamationCircleIcon,
+  ClockIcon,
   MagnifyingGlassIcon,
   UserGroupIcon,
   XCircleIcon,

--- a/src/context/SettingsProvider.tsx
+++ b/src/context/SettingsProvider.tsx
@@ -13,6 +13,8 @@ interface SettingsContextProps {
   setSoundEffect: (v: string) => void;
   scanDevice: string;
   setScanDevice: (v: string) => void;
+  requireRegistrationStateComplete: boolean;
+  setRequireRegistrationStateComplete: (v: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextProps>({
@@ -28,6 +30,8 @@ export const SettingsContext = createContext<SettingsContextProps>({
   setSoundEffect: () => {},
   scanDevice: 'Camera',
   setScanDevice: () => {},
+  requireRegistrationStateComplete: false,
+  setRequireRegistrationStateComplete: () => {},
 });
 
 export const SettingsProvider = ({children}: {children: ReactNode}) => {
@@ -52,6 +56,13 @@ export const SettingsProvider = ({children}: {children: ReactNode}) => {
 
   const [scanDevice, setScanDevice] = useState(localStorage.getItem('scanDevice') || 'Camera');
 
+  const storedRequireRegistrationStateComplete = JSON.parse(
+    localStorage.getItem('requireRegistrationStateComplete') || 'false'
+  );
+  const [requireRegistrationStateComplete, setRequireRegistrationStateComplete] = useState(
+    storedRequireRegistrationStateComplete
+  );
+
   return (
     <SettingsContext.Provider
       value={{
@@ -67,6 +78,8 @@ export const SettingsProvider = ({children}: {children: ReactNode}) => {
         setScanDevice,
         hapticFeedback,
         setHapticFeedback,
+        requireRegistrationStateComplete,
+        setRequireRegistrationStateComplete,
       }}
     >
       {children}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -40,6 +40,8 @@ function MainSettings() {
     setScanDevice,
     hapticFeedback,
     setHapticFeedback,
+    requireRegistrationStateComplete,
+    setRequireRegistrationStateComplete,
   } = useSettings();
 
   const toggleDarkMode = () => {
@@ -78,6 +80,14 @@ function MainSettings() {
     }
   };
 
+  const toggleRequireRegistrationStateComplete = () => {
+    localStorage.setItem(
+      'requireRegistrationStateComplete',
+      (!requireRegistrationStateComplete).toString()
+    );
+    setRequireRegistrationStateComplete(!requireRegistrationStateComplete);
+  };
+
   return (
     <div className="flex flex-col gap-6">
       <SettingsSection title="Check-in">
@@ -101,6 +111,12 @@ function MainSettings() {
             onToggle={toggleRapidMode}
           />
         )}
+        <SettingToggle
+          title="Require registration complete"
+          description="Check-in only registrations with complete (approved/paid) registration state"
+          checked={requireRegistrationStateComplete}
+          onToggle={toggleRequireRegistrationStateComplete}
+        />
         <SettingDropdown
           title="Check-in sound effect"
           values={Object.keys(sounds)}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -112,8 +112,8 @@ function MainSettings() {
           />
         )}
         <SettingToggle
-          title="Require registration complete"
-          description="Check-in only registrations with complete (approved/paid) registration state"
+          title="Require completed registrations"
+          description="Only check-in participants with a completed (approved or paid) registration state"
           checked={requireRegistrationStateComplete}
           onToggle={toggleRequireRegistrationStateComplete}
         />

--- a/src/pages/participant/ParticipantPage.tsx
+++ b/src/pages/participant/ParticipantPage.tsx
@@ -99,12 +99,12 @@ function ParticipantPageContent({
   const navigate = useNavigate();
   const {state} = useLocation();
   const [autoCheckin, setAutoCheckin] = useState(state?.autoCheckin ?? false);
-  const {soundEffect, hapticFeedback} = useSettings();
+  const {soundEffect, hapticFeedback, requireRegistrationStateComplete} = useSettings();
   const offline = useIsOffline();
   const errorModal = useErrorModal();
   const [notes, setNotes] = useState(participant?.notes || '');
   const showCheckedInWarning = useRef<boolean>(!!state?.fromScan && !!participant?.checkedIn);
-  const isRapidMode = useRef<boolean>(!!state.fromScan && !!state?.rapidMode);
+  const isRapidMode = useRef<boolean>(!!state?.fromScan && !!state?.rapidMode);
   const rapidModeTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
   const rapidModeTimeout = 3000;
   const [showProgressBar, setShowProgressBar] = useState<boolean>(isRapidMode.current);
@@ -220,7 +220,11 @@ function ParticipantPageContent({
       }
 
       setAutoCheckin(false);
-      if (autoCheckin && !participant.checkedIn) {
+      if (
+        autoCheckin &&
+        !participant.checkedIn &&
+        (!requireRegistrationStateComplete || participant.state === 'complete')
+      ) {
         await performCheckin(event, regform, participant, true);
       } else {
         await syncEvent(event, controller.signal, handleError);
@@ -321,14 +325,15 @@ function ParticipantPageContent({
               ))}
             </div>
           </div>
-
-          <div className="mb-4 mt-4 flex justify-center">
-            <CheckinToggle
-              checked={participant.checkedIn}
-              isLoading={!!participant.checkedInLoading}
-              onClick={onCheckInToggle}
-            />
-          </div>
+          {(!requireRegistrationStateComplete || participant.state === 'complete') && (
+            <div className="mb-4 mt-4 flex justify-center">
+              <CheckinToggle
+                checked={participant.checkedIn}
+                isLoading={!!participant.checkedInLoading}
+                onClick={onCheckInToggle}
+              />
+            </div>
+          )}
           {participant.state === 'unpaid' && (
             <PaymentWarning
               event={event}


### PR DESCRIPTION
This PR is to add 2 improvements: 
1. use icons to also depict withdrawn and rejected participants on the participant table, the cross out is not always easy to see when scrolling fast through a long list
2. add a setting to allow check-in only registrations that has been completed. If not enabled (the current way), all registration states (pending, rejected, withdrawn ...) can be checked in